### PR TITLE
Add themes to Nexus Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@
   * Analytics:
     * Provide reporting to Developers to help better solve issues
     * Disabled by default. Set `ALLOW_ANALYTICS` to true to enable.
+  * Themes:
+    * Choose a color scheme for your dashboard
 
 # Deployment
 
@@ -218,6 +220,9 @@ Run the following commands one at a time
 ##### Running the site
 You can run the site with
 `gunicorn -b :8000 -w 4 wsgi:app`
+
+# Configuring Dashboard
+If you want to change the theme of your dashboard, go into the `app` folder and open `themes.py` and change `APP_THEME` to the color you want. For example, `APP_THEME = "Blue"`
 
 # Development
 

--- a/app/THEMES.md
+++ b/app/THEMES.md
@@ -1,0 +1,38 @@
+# Themes for Nexus Dashboard
+
+This is how to use `themes.py` to change the look of your dashboard
+
+## Primary Color
+
+Editing the primary color (in the script this is `APP_THEME`) will change the colors of the navbar and buttons
+
+Here's the list of colors that are available to use in this python script
+
+	* `APP_THEME = "Blue"`:
+	  * Changes the navbar and button colors to Blue
+	* `APP_THEME = "Red"`:
+	  * Changes the navbar and button colors to Red
+	* `APP_THEME = "Green"`:
+	  * Changes the navbar and button colors to Green
+	* `APP_THEME = "Yellow"`:
+	  * Changes the navbar and button colors to Yellow
+	* `APP_THEME = "Black"`:
+	  * Changes the navbar and button colors to Black
+	* `APP_THEME = "Purple"`:
+	  * Changes the navbar and button colors to Purple
+
+## Font 
+
+Editing the font style (in the script this is `FONT_THEME` will change the look of the font on the dashboard
+
+Here's the list of font styles so far that are available to use in this python script
+
+	* `FONT_THEME = "Nunito"`:
+	  * This is currently the default font
+	* `FONT_THEME = "Grape Nuts"`:
+	* `FONT_THEME = "Odibee Sans"`:
+	* `FONT_THEME = "Righteous"`:
+
+## Applying the changes
+
+To apply the changes you have made, simply open up a command line and cd into the app directiory (This would be `NexusDashboard/app`), then you run `python3 themes.py` and you can see the changes on your dashboard

--- a/app/THEMES.md
+++ b/app/THEMES.md
@@ -8,18 +8,18 @@ Editing the primary color (in the script this is `APP_THEME`) will change the co
 
 Here's the list of colors that are available to use in this python script
 
-	* `APP_THEME = "Blue"`:
-	  * Changes the navbar and button colors to Blue
-	* `APP_THEME = "Red"`:
-	  * Changes the navbar and button colors to Red
-	* `APP_THEME = "Green"`:
-	  * Changes the navbar and button colors to Green
-	* `APP_THEME = "Yellow"`:
-	  * Changes the navbar and button colors to Yellow
-	* `APP_THEME = "Black"`:
-	  * Changes the navbar and button colors to Black
-	* `APP_THEME = "Purple"`:
-	  * Changes the navbar and button colors to Purple
+ * `APP_THEME = "Blue"`:
+    * Changes the navbar and button colors to Blue	  
+ * `APP_THEME = "Red"`:
+    * Changes the navbar and button colors to Red
+ * `APP_THEME = "Green"`:
+   * Changes the navbar and button colors to Green
+ * `APP_THEME = "Yellow"`:
+   * Changes the navbar and button colors to Yellow
+ * `APP_THEME = "Black"`:
+   * Changes the navbar and button colors to Black
+ * `APP_THEME = "Purple"`:
+   * Changes the navbar and button colors to Purple
 
 ## Font 
 
@@ -27,11 +27,11 @@ Editing the font style (in the script this is `FONT_THEME` will change the look 
 
 Here's the list of font styles so far that are available to use in this python script
 
-	* `FONT_THEME = "Nunito"`:
-	  * This is currently the default font
-	* `FONT_THEME = "Grape Nuts"`:
-	* `FONT_THEME = "Odibee Sans"`:
-	* `FONT_THEME = "Righteous"`:
+ * `FONT_THEME = "Nunito"`:
+   * This is currently the default font
+ * `FONT_THEME = "Grape Nuts"`
+ * `FONT_THEME = "Odibee Sans"`
+ * `FONT_THEME = "Righteous"`
 
 ## Applying the changes
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,7 +11,6 @@ from flask_user import user_registered, current_user, user_logged_in
 from flask_wtf.csrf import CSRFProtect
 from flask_apscheduler import APScheduler
 from app.luclient import register_luclient_jinja_helpers
-import app.themes
 
 from app.commands import (
     init_db,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ from flask_user import user_registered, current_user, user_logged_in
 from flask_wtf.csrf import CSRFProtect
 from flask_apscheduler import APScheduler
 from app.luclient import register_luclient_jinja_helpers
+import app.themes
 
 from app.commands import (
     init_db,

--- a/app/themes.py
+++ b/app/themes.py
@@ -23,5 +23,11 @@ if APP_THEME == "Green":
 if APP_THEME == "Yellow":
     HEX_CODE = "#FFCC00"
     openFile(HEX_CODE)
+if APP_THEME == "Black":
+    HEX_CODE = "#000000"
+    openFile(HEX_CODE)
+if APP_THEME == "Purple":
+    HEX_CODE = "#A020F0"
+    openFile(HEX_CODE)
 
 

--- a/app/themes.py
+++ b/app/themes.py
@@ -2,10 +2,10 @@ APP_THEME = "Blue"
 
 
 def openFile(theme):
-    with open("static/scss/site.scss", 'r') as f:
+    with open("app/static/scss/site.scss", 'r') as f:
         lines = f.readlines()
         newline = "        \"primary\": " + theme + "," + "\n"
-    with open("static/scss/site.scss", 'w') as f:
+    with open("app/static/scss/site.scss", 'w') as f:
         lines[2] = newline
         f.writelines(lines)
         f.close()
@@ -18,10 +18,10 @@ if APP_THEME == "Red":
     HEX_CODE = "#FF0000"
     openFile(HEX_CODE)
 if APP_THEME == "Green":
-    HEX_CODE = "#808000"
+    HEX_CODE = "#006400"
     openFile(HEX_CODE)
 if APP_THEME == "Yellow":
-    HEX_CODE = "#FFFF00"
+    HEX_CODE = "#FFCC00"
     openFile(HEX_CODE)
 
 

--- a/app/themes.py
+++ b/app/themes.py
@@ -1,4 +1,5 @@
 APP_THEME = "Blue"
+FONT_THEME = "Nunito"
 
 
 def openFile(theme):
@@ -7,6 +8,17 @@ def openFile(theme):
         newline = "        \"primary\": " + theme + "," + "\n"
     with open("app/static/scss/site.scss", 'w') as f:
         lines[2] = newline
+        f.writelines(lines)
+        f.close()
+
+def newFont(font_url, font):
+    with open("app/static/scss/site.scss", 'r') as f:
+        lines = f.readlines()
+        importline = "@import url(" + font_url + ");" + "\n"
+        bodyline = "body { font-family:'" + font + "', Helvetica, Arial, sans-serif; }" + "\n"
+    with open("app/static/scss/site.scss", 'w') as f:
+        lines[10] = importline
+        lines[12] = bodyline
         f.writelines(lines)
         f.close()
 
@@ -29,5 +41,23 @@ if APP_THEME == "Black":
 if APP_THEME == "Purple":
     HEX_CODE = "#A020F0"
     openFile(HEX_CODE)
+
+if FONT_THEME == "Nunito":
+    URL = "https://fonts.googleapis.com/css?family=Nunito:700"
+    FONT_NAME = "Nunito"
+    newFont(URL, FONT_NAME)
+if FONT_THEME == "Grape Nuts":
+    URL = "https://fonts.googleapis.com/css2?family=Grape+Nuts&display=swap"
+    FONT_NAME = "Grape Nuts"
+    newFont(URL, FONT_NAME)
+if FONT_THEME == "Odibee Sans":
+    URL = "https://fonts.googleapis.com/css2?family=Odibee+Sans&display=swap"
+    FONT_NAME = "Odibee Sans"
+    newFont(URL, FONT_NAME)
+if FONT_THEME == "Righteous":
+    URL = "https://fonts.googleapis.com/css2?family=Righteous&display=swap"
+    FONT_NAME = "Righteous"
+    newFont(URL, FONT_NAME)
+
 
 

--- a/app/themes.py
+++ b/app/themes.py
@@ -3,20 +3,20 @@ FONT_THEME = "Nunito"
 
 
 def openFile(theme):
-    with open("app/static/scss/site.scss", 'r') as f:
+    with open("static/scss/site.scss", 'r') as f:
         lines = f.readlines()
         newline = "        \"primary\": " + theme + "," + "\n"
-    with open("app/static/scss/site.scss", 'w') as f:
+    with open("static/scss/site.scss", 'w') as f:
         lines[2] = newline
         f.writelines(lines)
         f.close()
 
 def newFont(font_url, font):
-    with open("app/static/scss/site.scss", 'r') as f:
+    with open("static/scss/site.scss", 'r') as f:
         lines = f.readlines()
         importline = "@import url(" + font_url + ");" + "\n"
         bodyline = "body { font-family:'" + font + "', Helvetica, Arial, sans-serif; }" + "\n"
-    with open("app/static/scss/site.scss", 'w') as f:
+    with open("static/scss/site.scss", 'w') as f:
         lines[10] = importline
         lines[12] = bodyline
         f.writelines(lines)
@@ -58,6 +58,8 @@ if FONT_THEME == "Righteous":
     URL = "https://fonts.googleapis.com/css2?family=Righteous&display=swap"
     FONT_NAME = "Righteous"
     newFont(URL, FONT_NAME)
+
+print("Updated Dashboard Theme")
 
 
 

--- a/app/themes.py
+++ b/app/themes.py
@@ -1,0 +1,25 @@
+APP_THEME = "Blue"
+
+
+def openFile(theme):
+    with open("static/scss/site.scss", 'r') as f:
+        lines = f.readlines()
+        primary = lines[2]
+        print(primary)
+        print("        \"primary\": " + theme + ",")
+
+
+if APP_THEME == "Blue":
+    HEX_CODE = "#005ac2"
+    openFile(HEX_CODE)
+if APP_THEME == "Red":
+    HEX_CODE = "#FF0000"
+    openFile(HEX_CODE)
+if APP_THEME == "Green":
+    HEX_CODE = "#808000"
+    openFile(HEX_CODE)
+if APP_THEME == "Yellow":
+    HEX_CODE = "#FFFF00"
+    openFile(HEX_CODE)
+
+

--- a/app/themes.py
+++ b/app/themes.py
@@ -4,9 +4,11 @@ APP_THEME = "Blue"
 def openFile(theme):
     with open("static/scss/site.scss", 'r') as f:
         lines = f.readlines()
-        primary = lines[2]
-        print(primary)
-        print("        \"primary\": " + theme + ",")
+        newline = "        \"primary\": " + theme + "," + "\n"
+    with open("static/scss/site.scss", 'w') as f:
+        lines[2] = newline
+        f.writelines(lines)
+        f.close()
 
 
 if APP_THEME == "Blue":


### PR DESCRIPTION
Title speaks for itself

This is the current theme we all know and love
![image](https://user-images.githubusercontent.com/55319774/169125148-e1956b29-4ef9-4895-bcbf-09436e1d9c52.png)

This is the red theme
![image](https://user-images.githubusercontent.com/55319774/169126322-dde46f1c-5fca-409c-be25-1dd05f317c38.png)

This is the green theme
![image](https://user-images.githubusercontent.com/55319774/169128217-185bdae5-3594-46c7-bbc1-7a20f49b16f5.png)

This is the yellow theme
![image](https://user-images.githubusercontent.com/55319774/169129695-f3011b05-4a3b-4441-a422-ede006a1523d.png)

Still working on stuff such as making sure the text is also visible in different themes and adding more themes, this is currently a WIP. 

~~I also need to find a way to integrate this so when you run Nexus Dashboard it runs this to apply the current theme of course~~

Make this python script apply changes to the Dashboard's CSS
