### PR TITLE
Rename cdclient.sqlite to CDServer.sqlite to match DLU installation instructions

### DIFF
--- a/app/luclient.py
+++ b/app/luclient.py
@@ -191,7 +191,7 @@ def get_cdclient():
     """
     cdclient = getattr(g, '_cdclient', None)
     if cdclient is None:
-        cdclient = g._database = sqlite3.connect('app/luclient/res/cdclient.sqlite')
+        cdclient = g._database = sqlite3.connect('app/luclient/res/CDServer.sqlite')
     return cdclient
 
 


### PR DESCRIPTION
The DLU Server instructions say:
> Move and rename cdclient.sqlite into build/res/CDServer.sqlite
However, this application looks for `cdclient.sqlite`. This 1-line PR syncs the two requirements instead of requiring users to have two similarly named copies of the database in their client. Of course, I would prefer the DLU Server use cdclient, but I doubt that will change. Since this is a dashboard for the DLU Server, I figured this was the correct place to make this PR.
Thanks!