### PR TITLE
Fixed default value for play_key_id

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -70,7 +70,8 @@ class CustomRegisterForm(FlaskForm):
         validators=[
             Optional(),
             validate_play_key,
-        ]
+        ],
+        default=''
     )
 
     password = PasswordField('Password', validators=[


### PR DESCRIPTION
Turns out, at some point this started causing a 500 error upon registration when play keys were disabled. Issue was because `play_key_id` was none. This PR makes it default to an empty string.