### PR TITLE
Fix DB connection URL in env.py

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -22,8 +22,8 @@ logger = logging.getLogger('alembic.env')
 # target_metadata = mymodel.Base.metadata
 config.set_main_option(
     'sqlalchemy.url',
-    str(current_app.extensions['migrate'].db.get_engine().url).replace(
-        '%', '%%'))
+    current_app.config.get('SQLALCHEMY_DATABASE_URI')
+)
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,


### PR DESCRIPTION
Previously, this line was returning `***` as the DB password.

C.f. <https://github.com/miguelgrinberg/microblog/blob/c775a16faa08d4cbe56da03815888bbbafc1a611/migrations/env.py#L21-L22>