### PR TITLE
fix: pin bcrypt to 4.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ app/settings.py
 *.exe
 *.csv
 *.sql
+bin
+lib
+include

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.7.5
 autopep8==1.6.0
+bcrypt==4.0.1
 email-validator==1.1.3
 Flask==3.0.0
 Flask-APScheduler==1.12.3


### PR DESCRIPTION
fixes issue in the now abandoned(?) passlib library where passwords could not be hashed

also ignore the venv files